### PR TITLE
Update the AdAccountGroup call to correctly return adaccounts

### DIFF
--- a/src/FacebookAds/Object/AdAccountGroup.php
+++ b/src/FacebookAds/Object/AdAccountGroup.php
@@ -98,9 +98,9 @@ class AdAccountGroup extends AbstractCrudObject {
    * @param array $params
    * @return Cursor
    */
-  public function getAccounts(
+  public function getAdAccounts(
     array $fields = array(), array $params = array()) {
     return $this->getManyByConnection(
-      AdAccountGroupUser::className(), $fields, $params, 'accounts');
+      AdAccountGroupUser::className(), $fields, $params, 'adaccounts');
   }
 }

--- a/test/FacebookAdsTest/Object/AdAccountGroupTest.php
+++ b/test/FacebookAdsTest/Object/AdAccountGroupTest.php
@@ -38,7 +38,7 @@ class AdAccountGroupTest extends AbstractCrudObjectTestCase {
       AdAccountGroupFields::NAME => $this->getTestRunId().' updated'));
 
     $this->assertCanFetchConnection($group, 'getUsers');
-    $this->assertCanFetchConnection($group, 'getAccounts');
+    $this->assertCanFetchConnection($group, 'getAdAccounts');
 
     $this->assertCanDelete($group);
   }


### PR DESCRIPTION
Update the unit tests to correctly call gettting of adaccounts

The unit tests were failing for getAccounts, it was returning an unsupported get Request error

To get all adaccounts for an ad group use:
https://graph.facebook.com/AdAccountGroupId/adaccounts

see here:
https://developers.facebook.com/docs/reference/ads-api/adaccountgroup
