### PR TITLE
Update the pageid used in Unit Tests for ad creation to be dynamic.

### DIFF
--- a/test/Bootstrap.php
+++ b/test/Bootstrap.php
@@ -75,6 +75,7 @@ abstract class Bootstrap {
     AbstractTestCase::$appSecret = self::$config['app_secret'];
     AbstractTestCase::$accessToken = self::$config['access_token'];
     AbstractTestCase::$actId = self::$config['act_id'];
+    AbstractTestCase::$pageId = self::$config['page_id'];
     AbstractTestCase::$testRunId = md5(
       (isset($_SERVER['LOGNAME']) ? $_SERVER['LOGNAME'] : uniqid(true))
       .microtime(true));

--- a/test/FacebookAdsTest/AbstractTestCase.php
+++ b/test/FacebookAdsTest/AbstractTestCase.php
@@ -57,6 +57,11 @@ class AbstractTestCase extends \PHPUnit_Framework_TestCase {
   /**
    * @var string
    */
+  public static $pageId;
+
+  /**
+   * @var string
+   */
   public static $testRunId;
 
   /**
@@ -100,6 +105,13 @@ class AbstractTestCase extends \PHPUnit_Framework_TestCase {
    */
   public function getActId() {
     return static::$actId;
+  }
+
+  /**
+   * @return string
+   */
+  public function getPageId() {
+    return static::$pageId;
   }
 
   /**

--- a/test/FacebookAdsTest/Object/AdCreativeTest.php
+++ b/test/FacebookAdsTest/Object/AdCreativeTest.php
@@ -34,7 +34,7 @@ class AdCreativeTest extends AbstractCrudObjectTestCase {
     $creative->{AdCreativeFields::TITLE} = 'My Test Ad';
     $creative->{AdCreativeFields::NAME} = 'My Test Ad';
     $creative->{AdCreativeFields::BODY} = 'My Test Ad Body';
-    $creative->{AdCreativeFields::OBJECT_ID} = 259481254206516;
+    $creative->{AdCreativeFields::OBJECT_ID} = $this->getPageId();
     $this->assertCanCreate($creative);
     $this->assertCanRead($creative);
     $this->assertCanUpdate(

--- a/test/FacebookAdsTest/Object/AdGroupTest.php
+++ b/test/FacebookAdsTest/Object/AdGroupTest.php
@@ -74,7 +74,7 @@ class AdGroupTest extends AbstractCrudObjectTestCase {
     $this->adCreative = new AdCreative(null, $this->getActId());
     $this->adCreative->{AdCreativeFields::TITLE} = 'My Test Ad';
     $this->adCreative->{AdCreativeFields::BODY} = 'My Test Ad Body';
-    $this->adCreative->{AdCreativeFields::OBJECT_ID} = 20531316728;
+    $this->adCreative->{AdCreativeFields::OBJECT_ID} = $this->getPageId();
     $this->adCreative->create();
   }
 
@@ -84,7 +84,7 @@ class AdGroupTest extends AbstractCrudObjectTestCase {
     $this->adCampaign->delete();
     $this->adCampaign = null;
     $this->adCreative->delete();
-    $this->adCreative = null;    
+    $this->adCreative = null;
     parent::tearDown();
   }
 

--- a/test/FacebookAdsTest/Object/AdPreviewTest.php
+++ b/test/FacebookAdsTest/Object/AdPreviewTest.php
@@ -83,7 +83,7 @@ class AdPreviewTest extends AbstractCrudObjectTestCase {
     $this->adCreative = new AdCreative(null, $this->getActId());
     $this->adCreative->{AdCreativeFields::TITLE} = 'My Test Ad';
     $this->adCreative->{AdCreativeFields::BODY} = 'My Test Ad Body';
-    $this->adCreative->{AdCreativeFields::OBJECT_ID} = 20531316728;
+    $this->adCreative->{AdCreativeFields::OBJECT_ID} = $this->getPageId();
     $this->adCreative->create();
 
     $targeting = new TargetingSpecs();
@@ -152,7 +152,7 @@ class AdPreviewTest extends AbstractCrudObjectTestCase {
       array(
         AdPreviewFields::CREATIVE => array(
           AdCreativeFields::BODY => 'Testing the creative preview',
-          AdCreativeFields::OBJECT_ID => 259481254206516,
+          AdCreativeFields::OBJECT_ID => $this->getPageId(),
         ),
         AdPreviewFields::AD_FORMAT => AdFormats::RIGHT_COLUMN_STANDARD,
       )

--- a/test/config.php.dist
+++ b/test/config.php.dist
@@ -28,4 +28,5 @@ return array(
   'access_token' => '',
   'act_id' => '',
   'act_timezone' => '',
+  'page_id' => '',
 );


### PR DESCRIPTION
You must be an admin of the page specified to create an ad for it.

The page listed is Facebook's page, and it throws errors for non-admins when trying to run unit tests.
