### PR TITLE
Revert "Fix for PROMOTED_OBJECT missing from AdSet (2.2.0API)"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "neovdr/facebook-php-ads-sdk",
+    "name": "facebook/php-ads-sdk",
     "description": "PHP SDK for Facebook ads",
     "type": "library",
     "license": "Facebook Platform",

--- a/src/FacebookAds/Object/AdSet.php
+++ b/src/FacebookAds/Object/AdSet.php
@@ -62,7 +62,6 @@ class AdSet extends AbstractArchivableCrudObject {
     AdSetFields::TARGETING,
     AdSetFields::BID_TYPE,
     AdSetFields::BID_INFO,
-    AdSetFields::PROMOTED_OBJECT,
   );
 
   /**

--- a/src/FacebookAds/Object/Fields/AdSetFields.php
+++ b/src/FacebookAds/Object/Fields/AdSetFields.php
@@ -44,6 +44,5 @@ abstract class AdSetFields {
   const RF_PREDICTION_ID = 'rf_prediction_id';
   const UPDATED_TIME = 'updated_time';
   const TARGETING = 'targeting';
-  const PROMOTED_OBJECT = 'promoted_object';
 
 }


### PR DESCRIPTION
Reverts facebook/facebook-php-ads-sdk#27
