### PR TITLE
Added missing updated_time field in FacebookAds\Object\AdSet

### DIFF
--- a/src/FacebookAds/Object/AdSet.php
+++ b/src/FacebookAds/Object/AdSet.php
@@ -64,6 +64,7 @@ class AdSet extends AbstractArchivableCrudObject
     AdSetFields::BID_TYPE,
     AdSetFields::BID_INFO,
     AdSetFields::PROMOTED_OBJECT,
+    AdSetFields::UPDATED_TIME,
   );
 
   /**


### PR DESCRIPTION
AdSet object is missing UPDATE_TIME which is already present in Fields constants definition AdSetFields. Tested and worked.