### PR TITLE
Added missing getAdGroups function to AdCampaign

### DIFF
--- a/src/FacebookAds/Object/AdCampaign.php
+++ b/src/FacebookAds/Object/AdCampaign.php
@@ -82,6 +82,15 @@ class AdCampaign extends AbstractArchivableCrudObject {
    * @param array $params
    * @return Cursor
    */
+  public function getAdGroups(array $fields = array(), array $params = array()) {
+    return $this->getManyByConnection(AdGroup::className(), $fields, $params);
+  }
+
+  /**
+   * @param array $fields
+   * @param array $params
+   * @return Cursor
+   */
   public function getStats(array $fields = array(), array $params = array()) {
     return $this->getManyByConnection(
       AdStats::className(), $fields, $params, 'stats');

--- a/test/FacebookAdsTest/Object/AdCampaignTest.php
+++ b/test/FacebookAdsTest/Object/AdCampaignTest.php
@@ -39,6 +39,7 @@ class AdCampaignTest extends AbstractCrudObjectTestCase {
       $campaign,
       array(AdCampaignFields::NAME => $this->getTestRunId().' updated'));
     $this->assertCanFetchConnection($campaign, 'getAdSets');
+    $this->assertCanFetchConnection($campaign, 'getAdGroups');
     $this->assertCanFetchConnection($campaign, 'getStats');
 
     $this->assertCanArchive($campaign);


### PR DESCRIPTION
The Facebook API Documentation states that an Ad Campaign has **adgroup** connections apart from ad sets.
[Source here](https://developers.facebook.com/docs/marketing-api/adcampaign/v2.2#connections)

This pull request adds a getAdGroups function in the AdCampaign object alongside the getAdSets function.