### PR TITLE
Add "thumbnails" field for Ad Video.

### DIFF
--- a/src/FacebookAds/Object/AdVideo.php
+++ b/src/FacebookAds/Object/AdVideo.php
@@ -50,6 +50,7 @@ class AdVideo extends AbstractCrudObject {
     AdVideoFields::PICTURE,
     AdVideoFields::SOURCE,
     AdVideoFields::UPDATED_TIME,
+    AdVideoFields::THUMBNAILS
   );
 
   /**

--- a/src/FacebookAds/Object/Fields/AdVideoFields.php
+++ b/src/FacebookAds/Object/Fields/AdVideoFields.php
@@ -37,4 +37,5 @@ abstract class AdVideoFields {
   const PICTURE = 'picture';
   const SOURCE = 'source';
   const UPDATED_TIME = 'updated_time';
+  const THUMBNAILS = 'thumbnails';
 }


### PR DESCRIPTION
This allows AdVideo to request thumbnails field as demonstrated in Facebook Developer [docs](https://developers.facebook.com/docs/marketing-api/advideo#create_example).