### PR TITLE
Add spend_cap field for AdCampaign

### DIFF
--- a/src/FacebookAds/Object/AdCampaign.php
+++ b/src/FacebookAds/Object/AdCampaign.php
@@ -53,6 +53,7 @@ class AdCampaign extends AbstractArchivableCrudObject {
     AdCampaignFields::STATUS,
     AdCampaignFields::BUYING_TYPE,
     AdCampaignFields::PROMOTED_OBJECT,
+    AdCampaignFields::SPEND_CAP
   );
 
   /**

--- a/src/FacebookAds/Object/Fields/AdCampaignFields.php
+++ b/src/FacebookAds/Object/Fields/AdCampaignFields.php
@@ -34,4 +34,5 @@ abstract class AdCampaignFields {
   const IS_COMPLETED = 'is_completed';
   const BUYING_TYPE = 'buying_type';
   const PROMOTED_OBJECT = 'promoted_object';
+  const SPEND_CAP = 'spend_cap';
 }


### PR DESCRIPTION
According to official documentation:
https://developers.facebook.com/docs/marketing-api/adcampaign/v2.3#create