### PR TITLE
Add name to AdImageFields.

### DIFF
--- a/src/FacebookAds/Object/Fields/AdImageFields.php
+++ b/src/FacebookAds/Object/Fields/AdImageFields.php
@@ -40,4 +40,5 @@ class AdImageFields extends AbstractEnum {
   const HEIGHT = 'height';
   const ORIGINAL_WIDTH = 'original_width';
   const ORIGINAL_HEIGHT = 'original_height';
+  const NAME = 'name';
 }


### PR DESCRIPTION
The name field is the original name of the uploaded image in the
image library. This is useful for checking to see that an image
has already been uploaded.