### PR TITLE
Add __isset magic method

### DIFF
--- a/src/FacebookAds/Object/AbstractObject.php
+++ b/src/FacebookAds/Object/AbstractObject.php
@@ -60,6 +60,14 @@ abstract class AbstractObject {
   }
 
   /**
+   * @param string $name
+   * @return boolean
+   */
+  public function __isset($name) {
+    return array_key_exists($name, $this->data);
+  }
+
+  /**
    * @param array
    * @return $this
    */


### PR DESCRIPTION
Allows to use isset() function to check if a value is present in the case the property doesn't exist (example : the description field in behaviors).