### PR TITLE
Add missing bid_type ad group field.

### DIFF
--- a/src/FacebookAds/Object/Fields/AdGroupFields.php
+++ b/src/FacebookAds/Object/Fields/AdGroupFields.php
@@ -53,4 +53,5 @@ class AdGroupFields extends AbstractEnum {
   const ADLABELS = 'adlabels';
   const ENGAGEMENT_AUDIENCE = 'engagement_audience';
   const EXECUTION_OPTIONS = 'execution_options';
+  const BID_TYPE = 'bid_type';
 }


### PR DESCRIPTION
There was an api error: `bid_type is not a field of FacebookAds\Object\AdGroup` This commit should fix it.