### PR TITLE
Add fields and params parameters to async getResult.

### DIFF
--- a/src/FacebookAds/Object/AbstractAsyncJobObject.php
+++ b/src/FacebookAds/Object/AbstractAsyncJobObject.php
@@ -75,7 +75,11 @@ abstract class AbstractAsyncJobObject extends AbstractCrudObject {
   }
 
   /**
+   * @param array $fields
+   * @param array $params
+   *
    * @return mixed
    */
-  abstract public function getResult();
+  abstract public function getResult(
+    array $fields = array(), array $params = array());
 }

--- a/src/FacebookAds/Object/AsyncJobInsights.php
+++ b/src/FacebookAds/Object/AsyncJobInsights.php
@@ -51,10 +51,14 @@ class AsyncJobInsights extends AbstractAsyncJobObject {
   }
 
   /**
+   * @param array $fields
+   * @param array $params
+   *
    * @return Cursor
    */
-  public function getResult() {
+  public function getResult(
+    array $fields = array(), array $params = array()) {
     return $this->getManyByConnection(
-      Insights::classname(), array(), array(), $this->getEndpoint());
+      Insights::classname(), $fields, $params, $this->getEndpoint());
   }
 }


### PR DESCRIPTION
Currently the async insights job is limited to 25 results per page, adding these two parameters allows us to control the output of the async job result.