### PR TITLE
Added is_instagram_eligible field on AdVideo

### DIFF
--- a/src/FacebookAds/Object/Fields/AdVideoFields.php
+++ b/src/FacebookAds/Object/Fields/AdVideoFields.php
@@ -46,4 +46,5 @@ class AdVideoFields extends AbstractEnum {
   const SOURCE = 'source';
   const UPDATED_TIME = 'updated_time';
   const THUMBNAILS = 'thumbnails';
+  const IS_INSTAGRAM_ELIGIBLE = 'is_instagram_eligible';
 }

--- a/src/FacebookAds/Object/Fields/AdVideoFields.php
+++ b/src/FacebookAds/Object/Fields/AdVideoFields.php
@@ -39,12 +39,12 @@ class AdVideoFields extends AbstractEnum {
   const FROM = 'from';
   const ICON = 'icon';
   const ID = 'id';
+  const IS_INSTAGRAM_ELIGIBLE = 'is_instagram_eligible';
   const NAME = 'name';
   const PICTURE = 'picture';
   const PUBLISHED = 'published';
   const SLIDESHOW_SPEC = 'slideshow_spec';
   const SOURCE = 'source';
-  const UPDATED_TIME = 'updated_time';
   const THUMBNAILS = 'thumbnails';
-  const IS_INSTAGRAM_ELIGIBLE = 'is_instagram_eligible';
+  const UPDATED_TIME = 'updated_time';
 }


### PR DESCRIPTION
Added missing 'is_instagram_eligible' field on AdVideo documented here: https://developers.facebook.com/docs/marketing-api/guides/instagramads/ads_management/v2.5. Absence of field in enum makes it impossible to use the SDK to fetch videos if is_instagram_eligible is a field that needs to be fetched.