### PR TITLE
Add LinkDataFields Const Parameter

### DIFF
--- a/src/FacebookAds/Object/Fields/ObjectStory/LinkDataFields.php
+++ b/src/FacebookAds/Object/Fields/ObjectStory/LinkDataFields.php
@@ -42,4 +42,5 @@ class LinkDataFields extends AbstractEnum {
   const NAME = 'name';
   const PICTURE = 'picture';
   const MULTI_SHARE_OPTIMIZED = 'multi_share_optimized';
+  const MULTI_SHARE_END_CARD = 'multi_share_end_card';
 }


### PR DESCRIPTION
https://developers.facebook.com/docs/marketing-api/guides/carousel-ads#create

I want to create Carousel Ads, but this parameter "multi_share_end_card" is missing.
I Fix this And I want to use them , Please 