### PR TITLE
Fix bug on trim for email normalizer

### DIFF
--- a/test/FacebookAdsTest/Object/CustomAudienceNormalizers/EmailNormalizerTest.php
+++ b/test/FacebookAdsTest/Object/CustomAudienceNormalizers/EmailNormalizerTest.php
@@ -22,29 +22,37 @@
  *
  */
 
-namespace FacebookAds\Object\CustomAudienceNormalizers;
+namespace FacebookAdsTest\Object\CustomAudienceNormalizers;
 
-use FacebookAds\Object\CustomAudienceMultiKey;
-use FacebookAds\Object\Fields\CustomAudienceMultikeySchemaFields;
-use FacebookAds\Object\CustomAudienceNormalizers\ValueNormalizerInterface;
+use FacebookAdsTest\AbstractUnitTestCase;
+use FacebookAds\Object\CustomAudienceNormalizers\EmailNormalizer;
 
-class EmailNormalizer implements ValueNormalizerInterface {
+class EmailNormalizerTest extends AbstractUnitTestCase {
 
-  /**
-   * @param string $key
-   * @param string $key_value
-   * @return boolean
-   */
-  public function shouldNormalize($key, $key_value) {
-    return $key === CustomAudienceMultikeySchemaFields::EMAIL;
-  }
+    /**
+     * @var EmailNormalizer
+     */
+    protected $emailNormalizer;
 
-  /**
-   * @param string $key
-   * @param string $key_value
-   * @return string
-   */
-  public function normalize($key, $key_value) {
-    return trim(strtolower($key_value), " \t\r\n\0\x0B.");
-  }
+    public function setUp() {
+        $this->emailNormalizer = new EmailNormalizer();
+    }
+
+    public function testNormalizeData() {
+        return array(
+            array(
+                "foo@fb.com\t\r\n\0\x0B.",
+                'foo@fb.com',
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider testNormalizeData
+     */
+    public function testNormalize($input, $expected) {
+        $this->assertEquals(
+            $expected,
+            $this->emailNormalizer->normalize('email', $input));
+    }
 }


### PR DESCRIPTION
A bug was introduced in 5aa78e8, it prevents email addresses to be normalized correctly.

Before
https://github.com/facebook/facebook-php-ads-sdk/commit/5aa78e8e53d7827c864a1de7d67dff06e7c9ee65#diff-4d9609ae7b83358e8d569ed95b65cff8L142

After
https://github.com/facebook/facebook-php-ads-sdk/commit/5aa78e8e53d7827c864a1de7d67dff06e7c9ee65#diff-f34336ec698ba804095ae23d13fabb3bR48