### PR TITLE
Add STATUS constant back to AdSetFields.php to make update of status possible

### DIFF
--- a/src/FacebookAds/Object/Fields/AdSetFields.php
+++ b/src/FacebookAds/Object/Fields/AdSetFields.php
@@ -54,4 +54,7 @@ class AdSetFields extends AbstractArchivableCrudObjectFields {
   const PROMOTED_OBJECT = 'promoted_object';
   const ADLABELS = 'adlabels';
   const PRODUCT_AD_BEHAVIOR = 'product_ad_behavior';
+  
+  // required to make updates of AdSet-Status possible
+  const STATUS = 'status';
 }


### PR DESCRIPTION
Update of AdSet Status is only possible, if this constant is available, otherwise the FieldValidation prevents the update:

`PHP message: PHP Fatal error:  Uncaught exception 'InvalidArgumentException' with message 'status is not a field of FacebookAds\Object\AdSet' in vendor/facebook/php-ads-sdk/src/FacebookAds/Object/Traits/FieldValidation.php:44`