### PR TITLE
add campaign, adset execution_options field

### DIFF
--- a/src/FacebookAds/Object/Fields/AdSetFields.php
+++ b/src/FacebookAds/Object/Fields/AdSetFields.php
@@ -54,4 +54,5 @@ class AdSetFields extends AbstractArchivableCrudObjectFields {
   const PROMOTED_OBJECT = 'promoted_object';
   const ADLABELS = 'adlabels';
   const PRODUCT_AD_BEHAVIOR = 'product_ad_behavior';
+  const EXECUTION_OPTIONS = 'execution_options';
 }

--- a/src/FacebookAds/Object/Fields/CampaignFields.php
+++ b/src/FacebookAds/Object/Fields/CampaignFields.php
@@ -43,4 +43,5 @@ class CampaignFields extends AbstractArchivableCrudObjectFields {
   const STOP_TIME = 'stop_time';
   const UPDATED_TIME = 'updated_time';
   const RECOMMENDATIONS = 'recommendations';
+  const EXECUTION_OPTIONS = 'execution_options';
 }


### PR DESCRIPTION
Old Pull Request: https://github.com/facebook/facebook-php-ads-sdk/pull/188
Sorry, I rebase wrong branch, and you can close old pull request.
Commit is  on master now, so I create new pull request.

`AdFields.php` already has `execution_options` fields, so I didn't change this.