### PR TITLE
Issue #218 - Allows for Campaigns/Ads to be paused and activated

### DIFF
--- a/src/FacebookAds/Object/AbstractArchivableCrudObject.php
+++ b/src/FacebookAds/Object/AbstractArchivableCrudObject.php
@@ -89,4 +89,32 @@ abstract class AbstractArchivableCrudObject extends AbstractCrudObject {
       array_merge($params, array(
         $this->getStatusParamName() => static::STATUS_DELETED)));
   }
+
+  /**
+   * Pause this object
+   *
+   * @param array $params
+   * @return void
+   */
+  public function pause(array $params = array()) {
+    $this->getApi()->call(
+      $this->getNodePath(),
+      RequestInterface::METHOD_POST,
+      array_merge($params, array(
+        $this->getStatusParamName() => static::STATUS_PAUSED)));
+  }
+
+  /**
+   * Activate this object
+   *
+   * @param array $params
+   * @return void
+   */
+  public function activate(array $params = array()) {
+    $this->getApi()->call(
+      $this->getNodePath(),
+      RequestInterface::METHOD_POST,
+      array_merge($params, array(
+        $this->getStatusParamName() => static::STATUS_ACTIVE)));
+  }
 }


### PR DESCRIPTION
This change allows any AbstractArchivableCrudObject to be able to be paused or activated through the API.  Addresses Issue #218.

```
use FacebookAds\Object\Campaign;
$campaign = new Campaign(<CAMPAIGN_ID>);

$campaign->pause();
// or
$campaign->activate();
```

or
```

use FacebookAds\Object\Ad;
$ad = new Ad(<AD_ID>);

$ad->pause();
// or
$ad->activate();
```
