### PR TITLE
formatParams to reuse normalizer instances

### DIFF
--- a/src/FacebookAds/Object/CustomAudience.php
+++ b/src/FacebookAds/Object/CustomAudience.php
@@ -390,13 +390,13 @@ class CustomAudience extends AbstractCrudObject {
 
     if ($type == CustomAudienceTypes::EMAIL
       || $type == CustomAudienceTypes::PHONE) {
+      $normalizer = new EmailNormalizer();
+      $hash_normalizer = new HashNormalizer();
       foreach ($users as &$user) {
         if ($type == CustomAudienceTypes::EMAIL) {
-          $normalizer = new EmailNormalizer();
           $user = $normalizer->normalize(CustomAudienceTypes::EMAIL, $user);
         }
         if (!$is_hashed) {
-          $hash_normalizer = new HashNormalizer();
           $user = $hash_normalizer->normalize(
             CustomAudienceTypes::EMAIL, $user);
         }


### PR DESCRIPTION
CustomAudience#formatParams changed to not create new instances of the stateless normalizers for each item being processed.
