### PR TITLE
Update CurlAdapter to parse JSON values in headers

### DIFF
--- a/src/FacebookAds/Http/Adapter/CurlAdapter.php
+++ b/src/FacebookAds/Http/Adapter/CurlAdapter.php
@@ -125,7 +125,9 @@ class CurlAdapter extends AbstractAdapter {
       if (strpos($line, ': ') === false) {
         $headers['http_code'] = $line;
       } else {
-        list ($key, $value) = explode(': ', $line);
+        $parts = explode(':', $line);
+        $key = array_shift($parts);
+        $value = implode(':', $parts);
         $headers[$key] = $value;
       }
     }


### PR DESCRIPTION
Facebook returns the rate limit header as a JSON string (https://developers.facebook.com/docs/marketing-api/insights/best-practices/v2.7) , and the current implementation of the CurlAdapter only returns the value up to the first colon.

So instead of

```json
"x-fb-ads-insights-throttle" => " {"app_id_util_pct": 0.00,"acc_id_util_pct": 0.00}"
```

it shows up as

```json
"x-fb-ads-insights-throttle" => " {"app_id_util_pct""
```

...which is less than helpful!

This fixes that problem.