### PR TITLE
Validates if curl handle is resource on __destruct()

### DIFF
--- a/src/FacebookAds/Http/Adapter/Curl/AbstractCurl.php
+++ b/src/FacebookAds/Http/Adapter/Curl/AbstractCurl.php
@@ -45,7 +45,9 @@ abstract class AbstractCurl implements CurlInterface {
   }
 
   public function __destruct() {
-    curl_close($this->handle);
+    if (is_resource($this->handle)) {
+      curl_close($this->handle);
+    }
   }
 
   /**


### PR DESCRIPTION
Due to prevent errors:

```
PHP Fatal error:  Uncaught ErrorException: curl_close() expects parameter 1 to be resource, integer given in /home/michal/Workspace/.../vendor/facebook/php-ads-sdk/src/FacebookAds/Http/Adapter/Curl/AbstractCurl.php:49
Stack trace:
#0 [internal function]: Illuminate\Foundation\Bootstrap\HandleExceptions->handleError(2, 'curl_close() ex...', '/home/michal/Wo...', 49, Array)
#1 /home/michal/Workspace/.../vendor/facebook/php-ads-sdk/src/FacebookAds/Http/Adapter/Curl/AbstractCurl.php(49): curl_close(0)
#2 [internal function]: FacebookAds\Http\Adapter\Curl\AbstractCurl->__destruct()
```