### PR TITLE
fix (AdReportRun): ensure AdReport is complete

### DIFF
--- a/src/FacebookAds/Object/AdReportRun.php
+++ b/src/FacebookAds/Object/AdReportRun.php
@@ -111,7 +111,8 @@ class AdReportRun extends AbstractCrudObject {
   }
 
   public function isComplete() {
-    return $this->{AdReportRunFields::ASYNC_PERCENT_COMPLETION} === 100;
+    return $this->{AdReportRunFields::ASYNC_PERCENT_COMPLETION} === 100
+      && $this->{AdReportRunFields::ASYNC_STATUS} === 'Job Completed';
   }
 
   /**


### PR DESCRIPTION
Async calls can with "$job{AdReportRunFields::ASYNC_PERCENT_COMPLETION} == 100" is not ensuring that call has been completed.
Sometimes, the server response returns as the following example:


```
 #data: array:33 [
    "account_id" => "..."
    "async_percent_completion" => 100
    "async_status" => "Job Running"
    "date_start" => "2017-02-05"
    "date_stop" => "2017-03-06"
    
  ]
```


So, a subsequent call to `getResult` would fail with:


` {"error":{"message":"Error accessing adreport job.","type":"OAuthException","code":2601,"error_subcode":1815107,"is_transient":true,"error_user_title":"Loading Async Ads Report Failed","error_user_msg":"Sorry, the report cannot be loaded successfully. Please check if your job status is completed instead of failed or running before fetching the data.","fbtrace_id":"CxKuVc\/Ignx"}}`


The actually completed response looks like:

```
 #data: array:33 [
    "account_id" => "..."
    "async_percent_completion" => 100
    "async_status" => "Job Completed"
    "date_start" => "2017-02-05"
    "date_stop" => "2017-03-06"
    ....
  ]
```

This patch also checks for `$this->{AdReportRunFields::ASYNC_STATUS} === 'Job Completed'` for that reason. 
This patch can be avoided if a server fix will be implemented.