### PR TITLE
Fix parsing headers bug in Curl adapter

### DIFF
--- a/src/FacebookAds/Http/Adapter/CurlAdapter.php
+++ b/src/FacebookAds/Http/Adapter/CurlAdapter.php
@@ -125,7 +125,7 @@ class CurlAdapter extends AbstractAdapter {
       if (strpos($line, ': ') === false) {
         $headers['http_code'] = $line;
       } else {
-        list ($key, $value) = explode(': ', $line);
+        list ($key, $value) = explode(': ', $line, 2);
         $headers[$key] = $value;
       }
     }

--- a/test/FacebookAdsTest/ApiTest.php
+++ b/test/FacebookAdsTest/ApiTest.php
@@ -117,6 +117,7 @@ class ApiTest extends AbstractUnitTestCase {
 
     $session = $this->createSessionMock();
     $session->method('getAppSecretProof')->willReturn('<APP_SECRET_PROOF>');
+    $session->method('getRequestParameters')->willReturn([]);
 
     $logger = $this->createLoggerMock();
     $logger->expects($this->exactly(2))->method('logRequest');


### PR DESCRIPTION
Before fix throttle headers look like this
```
 "x-fb-ads-insights-throttle" : "{\"app_id_util_pct\"",
```
After fix those should look correct and we will be able to adapt backend to react on throttling.