### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "homepage": "https://developers.facebook.com/",
     "require-dev" : {
-        "phpunit/phpunit": "~4.6",
+        "phpunit/phpunit": "~4.8.36",
         "symfony/finder": "~2.6"
     },
     "autoload": {

--- a/test/FacebookAdsTest/AbstractTestCase.php
+++ b/test/FacebookAdsTest/AbstractTestCase.php
@@ -27,12 +27,13 @@ namespace FacebookAdsTest;
 use FacebookAdsTest\Config\Config;
 use FacebookAdsTest\Config\SkippableFeaturesManager;
 use \PHPUnit_Framework_MockObject_Builder_InvocationMocker as Mock;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Base class for the unit test cases, providing the functions for AdsAPI
  * initialization etc.
  */
-class AbstractTestCase extends \PHPUnit_Framework_TestCase {
+class AbstractTestCase extends TestCase {
 
   /**
    * @return SkippableFeaturesManager


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump `PHPUnit` version to [`4.8.36`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4836---2017-06-21), that supports this `namespace`.