### PR TITLE
Sample Facebook Code Bug fix

### DIFF
--- a/src/FacebookAds/Logger/CurlLogger.php
+++ b/src/FacebookAds/Logger/CurlLogger.php
@@ -84,7 +84,6 @@ class CurlLogger implements LoggerInterface {
     if (!defined('STDOUT')) {
         define('STDOUT', fopen('php://stdout', 'w'));
     }
- 
     $this->handle = is_resource($handle) ? $handle : STDOUT;
   }
 

--- a/src/FacebookAds/Logger/CurlLogger.php
+++ b/src/FacebookAds/Logger/CurlLogger.php
@@ -81,7 +81,6 @@ class CurlLogger implements LoggerInterface {
    * @param resource $handle
    */
   public function __construct($handle = null) {
-    
     if (!defined('STDOUT')) {
         define('STDOUT', fopen('php://stdout', 'w'));
     }

--- a/src/FacebookAds/Logger/CurlLogger.php
+++ b/src/FacebookAds/Logger/CurlLogger.php
@@ -81,6 +81,11 @@ class CurlLogger implements LoggerInterface {
    * @param resource $handle
    */
   public function __construct($handle = null) {
+    
+    if (!defined('STDOUT')) {
+        define('STDOUT', fopen('php://stdout', 'w'));
+    }
+ 
     $this->handle = is_resource($handle) ? $handle : STDOUT;
   }
 


### PR DESCRIPTION
Use of undefined constant STDOUT - assumed 'STDOUT'. 
Checking if STDOUT exists if not define it.