### PR TITLE
Fix deprecation error for implicitly nullable parameter declarations in PHP 8.4

### DIFF
--- a/src/FacebookAds/Cursor.php
+++ b/src/FacebookAds/Cursor.php
@@ -63,7 +63,7 @@ class Cursor implements \Iterator, \Countable, \ArrayAccess {
   public function __construct(
     ResponseInterface $response,
     AbstractObject $object_prototype,
-    Api $api = null) {
+    ?Api $api = null) {
     $this->response = $response;
     $this->objectPrototype = $object_prototype;
     $this->api = $api !== null ? $api : Api::instance();

--- a/src/FacebookAds/Http/Adapter/CurlAdapter.php
+++ b/src/FacebookAds/Http/Adapter/CurlAdapter.php
@@ -47,9 +47,9 @@ class CurlAdapter extends AbstractAdapter {
 
   /**
    * @param Client $client
-   * @param CurlInterface $curl
+   * @param CurlInterface|null $curl
    */
-  public function __construct(Client $client, CurlInterface $curl = null) {
+  public function __construct(Client $client, ?CurlInterface $curl = null) {
     parent::__construct($client);
     $this->curl = $curl ?: AbstractCurl::createOptimalVersion();
     $this->curl->init();

--- a/src/FacebookAds/Object/AbstractCrudObject.php
+++ b/src/FacebookAds/Object/AbstractCrudObject.php
@@ -38,9 +38,9 @@ class AbstractCrudObject extends AbstractObject {
    * @deprecated deprecate constructor with null and parent_id
    * @param string $id Optional (do not set for new objects)
    * @param string $parent_id Optional, needed for creating new objects.
-   * @param Api $api The Api instance this object should use to make calls
+   * @param Api|null $api The Api instance this object should use to make calls
    */
-  public function __construct($id = null, $parent_id = null, Api $api = null) {
+  public function __construct($id = null, $parent_id = null, ?Api $api = null) {
     parent::__construct();
 
     // check that $id is an integer or a string integer or a string of
@@ -113,7 +113,7 @@ class AbstractCrudObject extends AbstractObject {
    * @return Api
    * @throws \InvalidArgumentException
    */
-  protected static function assureApi(Api $instance = null) {
+  protected static function assureApi(?Api $instance = null) {
     $instance = $instance ?: Api::instance();
     if (!$instance) {
       throw new \InvalidArgumentException(
@@ -457,10 +457,10 @@ class AbstractCrudObject extends AbstractObject {
    * Used batch API calls to delete multiple objects at once
    *
    * @param string[] $ids Array or single Object ID to delete
-   * @param Api $api Api Object to use
+   * @param Api|null $api Api Object to use
    * @return bool Returns true on success
    */
-  public static function deleteIds(array $ids, Api $api = null) {
+  public static function deleteIds(array $ids, ?Api $api = null) {
     $batch = array();
     foreach ($ids as $id) {
       $request = array(
@@ -488,14 +488,14 @@ class AbstractCrudObject extends AbstractObject {
    * @param mixed $ids Array or single object IDs
    * @param array $fields Array of field names to read
    * @param array $params Additional filters for the reading, in assoc
-   * @param Api $api Api Object to use
+   * @param Api|null $api Api Object to use
    * @return Cursor
    */
   public static function readIds(
     array $ids,
     array $fields = array(),
     array $params = array(),
-    Api $api = null) {
+    ?Api $api = null) {
     if (empty($fields)) {
       $fields = static::getDefaultReadFields();
     }

--- a/src/FacebookAds/Object/AdImage.php
+++ b/src/FacebookAds/Object/AdImage.php
@@ -77,11 +77,11 @@ class AdImage extends AbstractCrudObject {
    * @param string $file_path
    * @param string $account_id
    * @param array $params
-   * @param Api $api
+   * @param Api|null $api
    * @return array
    */
   public static function createFromZip(
-    $file_path, $account_id, array $params = array(), Api $api = null) {
+    $file_path, $account_id, array $params = array(), ?Api $api = null) {
 
     $image = new AdImage(null, $account_id, $api);
     $image->{AdImageFields::FILENAME} = $file_path;

--- a/src/FacebookAds/Object/BusinessDataAPI/Content.php
+++ b/src/FacebookAds/Object/BusinessDataAPI/Content.php
@@ -35,7 +35,7 @@ class Content {
    * Constructor
    * @param mixed[] $data Associated array of property value initializing the model
    */
-  public function __construct(array $data = null) {
+  public function __construct(array $data = []) {
     $this->container['product_id'] = isset($data['product_id']) ? $data['product_id'] : null;;
     $this->container['quantity'] = isset($data['quantity']) ? $data['quantity'] : null;
     $this->container['price'] = isset($data['price']) ? $data['price'] : null;

--- a/src/FacebookAds/Object/BusinessDataAPI/CustomData.php
+++ b/src/FacebookAds/Object/BusinessDataAPI/CustomData.php
@@ -36,7 +36,7 @@ class CustomData {
    * Constructor
    * @param mixed[] $data Associated array of property value initializing the model
    */
-  public function __construct(array $data = null) {
+  public function __construct(array $data = []) {
     $this->container['value'] = isset($data['value']) ? $data['value'] : null;
     $this->container['currency'] = isset($data['currency']) ? $data['currency'] : null;
     $this->container['contents'] = isset($data['contents']) ? $data['contents'] : null;

--- a/src/FacebookAds/Object/BusinessDataAPI/Event.php
+++ b/src/FacebookAds/Object/BusinessDataAPI/Event.php
@@ -36,7 +36,7 @@ class Event {
    * Constructor
    * @param mixed[] $data Associated array of property value initalizing the model
    */
-  public function __construct(array $data = null) {
+  public function __construct(array $data = []) {
     $this->container['event_name'] = isset($data['event_name']) ? $data['event_name'] : null;
     $this->container['event_time'] = isset($data['event_time']) ? $data['event_time'] : null;
     $this->container['event_id'] = isset($data['event_id']) ? $data['event_id'] : null;

--- a/src/FacebookAds/Object/BusinessDataAPI/EventRequest.php
+++ b/src/FacebookAds/Object/BusinessDataAPI/EventRequest.php
@@ -46,7 +46,7 @@ class EventRequest {
    * @param string $page_id page id
    * @param mixed[] $data Associated array of property value initializing the model
    */
-  public function __construct(string $page_id, array $data = null) {
+  public function __construct(string $page_id, array $data = []) {
     $this->container['page_id'] = $page_id;
     $this->container['events'] = isset($data['events']) ? $data['events'] : null;
   }

--- a/src/FacebookAds/Object/BusinessDataAPI/EventResponse.php
+++ b/src/FacebookAds/Object/BusinessDataAPI/EventResponse.php
@@ -41,7 +41,7 @@ class EventResponse {
    * Constructor
    * @param mixed[] $data Associated array of property value initalizing the model
    */
-  public function __construct(array $data = null) {
+  public function __construct(array $data = []) {
     $this->container['events_received'] = isset($data['events_received']) ? $data['events_received'] : null;
     $this->container['events_dropped'] = isset($data['events_dropped']) ? $data['events_dropped'] : null;
     $this->container['message'] = isset($data['message']) ? $data['message'] : null;

--- a/src/FacebookAds/Object/BusinessDataAPI/UserData.php
+++ b/src/FacebookAds/Object/BusinessDataAPI/UserData.php
@@ -41,7 +41,7 @@ class UserData {
    * Constructor
    * @param mixed[] $data Associated array of property value initalizing the model
    */
-  public function __construct(array $data = null) {
+  public function __construct(array $data = []) {
     $this->container['email'] = isset($data['email']) ? $data['email'] : null;
     $this->container['phone'] = isset($data['phone']) ? $data['phone'] : null;
     $this->container['date_of_birth'] = isset($data['date_of_birth']) ? $data['date_of_birth'] : null;

--- a/src/FacebookAds/Object/ServerSide/AdsPixelSettings.php
+++ b/src/FacebookAds/Object/ServerSide/AdsPixelSettings.php
@@ -47,7 +47,7 @@ class AdsPixelSettings implements ArrayAccess {
    * Constructor
    * @param mixed[] $data Associated array of property value initializing the model
    */
-  public function __construct(array $data = null) {
+  public function __construct(array $data = []) {
     $this->container['enable_automatic_matching'] = isset($data['enableAutomaticMatching']) ? $data['enableAutomaticMatching'] : null;;
     $this->container['enabled_automatic_matching_fields'] = isset($data['enabledAutomaticMatchingFields']) ? $data['enabledAutomaticMatchingFields'] : null;
     $this->container['pixel_id'] = isset($data['pixel_id']) ? $data['pixel_id'] : null;

--- a/src/FacebookAds/Object/ServerSide/AppData.php
+++ b/src/FacebookAds/Object/ServerSide/AppData.php
@@ -108,7 +108,7 @@ class AppData implements ArrayAccess {
 
   protected $container = array();
 
-  public function __construct(array $data = null) {
+  public function __construct(array $data = []) {
     $this->container['application_tracking_enabled'] = isset($data['application_tracking_enabled']) ? $data['application_tracking_enabled'] : null;
     $this->container['advertiser_tracking_enabled'] = isset($data['advertiser_tracking_enabled']) ? $data['advertiser_tracking_enabled'] : null;
     $this->container['app_user_id'] = isset($data['app_user_id']) ? $data['app_user_id'] : null;

--- a/src/FacebookAds/Object/ServerSide/AttributionData.php
+++ b/src/FacebookAds/Object/ServerSide/AttributionData.php
@@ -89,7 +89,7 @@ class AttributionData implements ArrayAccess {
 
   protected $container = array();
 
-  public function __construct(array $data = null) {
+  public function __construct(array $data = []) {
     $this->container['scope'] = isset($data['scope']) ? $data['scope'] : null;
     $this->container['visit_time'] = isset($data['visit_time']) ? $data['visit_time'] : null;
     $this->container['ad_id'] = isset($data['ad_id']) ? $data['ad_id'] : null;

--- a/src/FacebookAds/Object/ServerSide/Content.php
+++ b/src/FacebookAds/Object/ServerSide/Content.php
@@ -37,7 +37,7 @@ class Content implements ArrayAccess {
    * Constructor
    * @param mixed[] $data Associated array of property value initializing the model
    */
-  public function __construct(array $data = null) {
+  public function __construct(array $data = []) {
     $this->container['product_id'] = isset($data['product_id']) ? $data['product_id'] : null;;
     $this->container['quantity'] = isset($data['quantity']) ? $data['quantity'] : null;
     $this->container['item_price'] = isset($data['item_price']) ? $data['item_price'] : null;

--- a/src/FacebookAds/Object/ServerSide/CustomData.php
+++ b/src/FacebookAds/Object/ServerSide/CustomData.php
@@ -124,7 +124,7 @@ class CustomData implements ArrayAccess {
    * Constructor
    * @param mixed[] $data Associated array of property value initializing the model
    */
-  public function __construct(array $data = null) {
+  public function __construct(array $data = []) {
     $this->container['value'] = isset($data['value']) ? $data['value'] : null;
     $this->container['currency'] = isset($data['currency']) ? $data['currency'] : null;
     $this->container['content_name'] = isset($data['content_name']) ? $data['content_name'] : null;

--- a/src/FacebookAds/Object/ServerSide/CustomEndpointResponse.php
+++ b/src/FacebookAds/Object/ServerSide/CustomEndpointResponse.php
@@ -47,7 +47,7 @@ class CustomEndpointResponse {
      * Constructor
      * @param mixed[] $data Associated array of property value initializing the model
      */
-    public function __construct(array $data = null) {
+    public function __construct(array $data = []) {
         $this->container['message'] = isset($data['message']) ? $data['message'] : null;
         $this->container['response_code'] = isset($data['response_code']) ? $data['response_code'] : null;
     }

--- a/src/FacebookAds/Object/ServerSide/Event.php
+++ b/src/FacebookAds/Object/ServerSide/Event.php
@@ -132,7 +132,7 @@ class Event implements ArrayAccess {
    * Constructor
    * @param mixed[] $data Associated array of property value initializing the model
    */
-  public function __construct(array $data = null) {
+  public function __construct(array $data = []) {
     $this->container['event_name'] = isset($data['event_name']) ? $data['event_name'] : null;
     $this->container['event_time'] = isset($data['event_time']) ? $data['event_time'] : null;
     $this->container['event_source_url'] = isset($data['event_source_url']) ? $data['event_source_url'] : null;

--- a/src/FacebookAds/Object/ServerSide/EventRequest.php
+++ b/src/FacebookAds/Object/ServerSide/EventRequest.php
@@ -102,7 +102,7 @@ class EventRequest implements ArrayAccess {
    * @param string $pixel_id pixel id
    * @param mixed[] $data Associated array of property value initializing the model
    */
-  public function __construct($pixel_id, array $data = null) {
+  public function __construct($pixel_id, array $data = []) {
     $this->container['pixel_id'] = $pixel_id;
     $this->container['events'] = isset($data['events']) ? $data['events'] : null;
     $this->container['test_event_code'] = isset($data['test_event_code']) ? $data['test_event_code'] : null;

--- a/src/FacebookAds/Object/ServerSide/EventResponse.php
+++ b/src/FacebookAds/Object/ServerSide/EventResponse.php
@@ -83,7 +83,7 @@ class EventResponse implements ArrayAccess {
    * Constructor
    * @param mixed[] $data Associated array of property value initalizing the model
    */
-  public function __construct(array $data = null) {
+  public function __construct(array $data = []) {
     $this->container['events_received'] = isset($data['events_received']) ? $data['events_received'] : null;
     $this->container['messages'] = isset($data['messages']) ? $data['messages'] : null;
     $this->container['fbtrace_id'] = isset($data['fbtrace_id']) ? $data['fbtrace_id'] : null;

--- a/src/FacebookAds/Object/ServerSide/ExtendedDeviceInfo.php
+++ b/src/FacebookAds/Object/ServerSide/ExtendedDeviceInfo.php
@@ -123,7 +123,7 @@ class ExtendedDeviceInfo implements ArrayAccess {
 
   protected $container = array();
 
-  public function __construct(array $data = null) {
+  public function __construct(array $data = []) {
     $this->container['ext_info_version'] = isset($data['ext_info_version']) ? $data['ext_info_version'] : null;
     $this->container['app_package_name'] = isset($data['app_package_name']) ? $data['app_package_name'] : null;
     $this->container['short_version'] = isset($data['short_version']) ? $data['short_version'] : null;

--- a/src/FacebookAds/Object/ServerSide/OriginalEventData.php
+++ b/src/FacebookAds/Object/ServerSide/OriginalEventData.php
@@ -59,7 +59,7 @@ class OriginalEventData implements ArrayAccess {
 
   protected $container = array();
 
-  public function __construct(array $data = null) {
+  public function __construct(array $data = []) {
     $this->container['event_name'] = isset($data['event_name']) ? $data['event_name'] : null;
     $this->container['event_time'] = isset($data['event_time']) ? $data['event_time'] : null;
   }

--- a/src/FacebookAds/Object/ServerSide/UserData.php
+++ b/src/FacebookAds/Object/ServerSide/UserData.php
@@ -235,7 +235,7 @@ class UserData implements ArrayAccess {
    * Constructor
    * @param mixed[] $data Associated array of property value initalizing the model
    */
-  public function __construct(array $data = null) {
+  public function __construct(array $data = []) {
 
     # Let's make sure not both singular and plural parameters are set
     if(isset($data['email']) And isset($data['emails'])) {

--- a/src/FacebookAds/Object/Signal/Content.php
+++ b/src/FacebookAds/Object/Signal/Content.php
@@ -44,7 +44,7 @@ class Content {
    * Constructor
    * @param mixed[] $data Associated array of property value initializing the model
    */
-  public function __construct(array $data = null) {
+  public function __construct(array $data = []) {
     $this->businessDataContent = new BusinessDataContent($data);
     $this->serverSideContent = new ServerSideContent($data);
   }

--- a/src/FacebookAds/Object/Signal/CustomData.php
+++ b/src/FacebookAds/Object/Signal/CustomData.php
@@ -45,7 +45,7 @@ class CustomData {
    * Constructor
    * @param mixed[] $data Associated array of property value initializing the model
    */
-  public function __construct(array $data = null) {
+  public function __construct(array $data = []) {
     $business_contents = array();
     $server_contents = array();
     if(isset($data['contents'])){

--- a/src/FacebookAds/Object/Signal/Event.php
+++ b/src/FacebookAds/Object/Signal/Event.php
@@ -45,7 +45,7 @@ class Event {
    * Constructor
    * @param mixed[] $data Associated array of property value initalizing the model
    */
-  public function __construct(array $data = null) {
+  public function __construct(array $data = []) {
     $business_data = $data;
     $server_data = $data;
     $business_data['user_data'] = isset($data['user_data']) ? $data['user_data']->getBusinessDataUserData() : null;

--- a/src/FacebookAds/Object/Signal/EventRequest.php
+++ b/src/FacebookAds/Object/Signal/EventRequest.php
@@ -54,7 +54,7 @@ class EventRequest {
    * @param string $page_id page id
    * @param mixed[] $data Associated array of property value initializing the model
    */
-  public function __construct(string $pixel_id, string $page_id, array $data = null) {
+  public function __construct(string $pixel_id, string $page_id, array $data = []) {
     $business_data = $data;
     $server_data = $data;
 

--- a/src/FacebookAds/Object/Signal/UserData.php
+++ b/src/FacebookAds/Object/Signal/UserData.php
@@ -52,7 +52,7 @@ class UserData {
    * Constructor
    * @param mixed[] $data Associated array of property value initalizing the model
    */
-  public function __construct(array $data = null) {
+  public function __construct(array $data = []) {
     $this->businessDataUserData = new BusinessDataUserData($data);
     $this->serverSideUserData = new ServerSideUserData($data);
   }

--- a/src/FacebookAds/Object/TargetingSearch.php
+++ b/src/FacebookAds/Object/TargetingSearch.php
@@ -20,7 +20,7 @@ class TargetingSearch extends AbstractObject {
    * @param string $type
    * @param string $class
    * @param array $params
-   * @param Api $api
+   * @param Api|null $api
    * @return Cursor
    * @throws \InvalidArgumentException
    */
@@ -29,7 +29,7 @@ class TargetingSearch extends AbstractObject {
     $class=null,
     $query=null,
     array $params = array(),
-    Api $api = null) {
+    ?Api $api = null) {
 
     $api = $api ?: Api::instance();
     if (!$api) {

--- a/test/FacebookAdsTest/CursorTest.php
+++ b/test/FacebookAdsTest/CursorTest.php
@@ -95,7 +95,7 @@ class CursorTest extends AbstractUnitTestCase {
    * @return Mock|ResponseInterface
    */
   protected function createResponseChainMock(
-    $num_pages, RequestInterface $prev = null) {
+    $num_pages, ?RequestInterface $prev = null) {
 
     $query_params = $prev ? clone $prev->getQueryParams() : new Parameters();
     $sample_content = $this->createSampleResponseContent();


### PR DESCRIPTION
Fix deprecation error for implicitly nullable parameter declarations in PHP 8.4