### PR TITLE
fix: properly release CurlHandle in __destruct() for PHP 8.0+

### DIFF
--- a/src/FacebookAds/Http/Adapter/Curl/AbstractCurl.php
+++ b/src/FacebookAds/Http/Adapter/Curl/AbstractCurl.php
@@ -45,7 +45,11 @@ abstract class AbstractCurl implements CurlInterface {
   }
 
   public function __destruct() {
-    if ($this->handle instanceof \CurlHandle || is_resource($this->handle)) {
+    if ($this->handle instanceof \CurlHandle) {
+      // PHP 8.0+: curl_close() is a no-op; unset to release the handle and close the socket
+      $this->handle = null;
+    } elseif (is_resource($this->handle)) {
+      // PHP 7.x: curl_close() actually closes the underlying resource
       curl_close($this->handle);
     }
   }

--- a/src/FacebookAds/Http/Adapter/Curl/AbstractCurl.php
+++ b/src/FacebookAds/Http/Adapter/Curl/AbstractCurl.php
@@ -27,7 +27,7 @@ namespace FacebookAds\Http\Adapter\Curl;
 abstract class AbstractCurl implements CurlInterface {
 
   /**
-   * @var resource
+   * @var resource|\CurlHandle
    */
   protected $handle;
 
@@ -45,7 +45,7 @@ abstract class AbstractCurl implements CurlInterface {
   }
 
   public function __destruct() {
-    if (is_resource($this->handle)) {
+    if ($this->handle instanceof \CurlHandle || is_resource($this->handle)) {
       curl_close($this->handle);
     }
   }


### PR DESCRIPTION
`AbstractCurl::__destruct()` fails to close curl handles on PHP 8.0+, leaving TCP sockets open in `CLOSE_WAIT` for the lifetime of the PHP process.

  Two separate incompatibilities compound the problem:

  1. `is_resource($this->handle)` returns `false` on PHP 8.0+ because `curl_init()` now returns a `CurlHandle` **object**, not a `resource` — the guard condition is never true, so the entire block is skipped
  2. Even if the block were reached, `curl_close()` is a **no-op on PHP 8.0+** — the socket is only released when the `CurlHandle` object is destroyed via `unset()` / GC

  ## Root cause

  ```php
  // Before — broken on PHP 8.0+:
  public function __destruct() {
      if (is_resource($this->handle)) {  // always false on PHP 8+ → skipped entirely
          curl_close($this->handle);     // no-op on PHP 8+ even if reached
      }
  }
  ```

  ## Fix

  ```php
  // After:
  public function __destruct() {
      if ($this->handle instanceof \CurlHandle) {
          // PHP 8.0+: curl_close() is a no-op; null out the reference so the
          // CurlHandle refcount drops to zero and the socket is released immediately
          $this->handle = null;
      } elseif (is_resource($this->handle)) {
          // PHP 7.x: curl_close() still closes the underlying resource
          curl_close($this->handle);
      }
  }
  ```

  Also updates the `@var` docblock on `$handle` from `@var resource` to `@var resource|\CurlHandle`.

  ## PHP 8.0 migration context

  - `curl_init()` return type changed from `resource` to `CurlHandle` object — [PHP 8.0 migration guide](https://www.php.net/manual/en/migration80.other-changes.php)
  - `is_resource()` returns `false` for `CurlHandle` — type checks must use `instanceof \CurlHandle`
  - `curl_close()` is now a no-op; the PHP docs recommend explicit `unset()` to release the handle

  ## Impact

  In a long-running PHP CLI process (e.g. a Magento cron job), every HTTP call that ends with the remote closing the connection leaves an orphaned `CLOSE_WAIT` socket. These accumulate without bound and can exhaust file descriptors on
  high-uptime servers.

  We observed this in production with `facebook_business_extension_aam_settings_cronjob` (runs every 20 minutes). A single cron process had been running for 15+ hours with open Facebook sockets visible via `lsof`:

  ```
  php  28956  ...  IPv4  TCP ...:49604->edge-star-shv-01-lhr6.facebook.com:443 (CLOSE_WAIT)
  ```

  ## Environment

  | Field | Value |
  |---|---|
  | PHP | 8.1.16 (CLI) |
  | facebook/php-business-sdk | 9.0.3 |
  | OS | Linux / AWS EC2 (eu-west-1) |